### PR TITLE
[read-org] added 'reviewer requested from' org functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Get a list of open Pull Requests for a list of repositories by a particular user
 
 ```json
 {
-  "authToken": "<YOUR_TOKEN>", // Create a personal access token at https://github.com/settings/tokens/new?scopes=repo
+  "authToken": "<YOUR_TOKEN>", // Create a personal access token at https://github.com/settings/tokens/new?scopes=repo,read:org
   "usertype": "user", // "user" or "org"
   "owner": "james-work-account", // User/org the repos belong to
   "repoSearch": "todo", // Regex to search on. Will match repo names against this search term

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,9 @@ function performSearch() {
         ... on User {
           login
         }
+        ... on Team {
+          name
+        }
       }
     }
   }
@@ -198,7 +201,7 @@ function displayRepos() {
           ${
             pr.reviewRequests.nodes.length > 0
               ? `<li><strong>Review requested from</strong>: ${pr.reviewRequests.nodes
-                  .map((node) => node.requestedReviewer.login)
+                  .map((node) => node.requestedReviewer.login || node.requestedReviewer.name)
                   .join(", ")}</li>`
               : ""
           }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -30,7 +30,8 @@ type PullType = {
   reviewRequests: {
     nodes: {
       requestedReviewer: {
-        login: string;
+        login?: string;
+        name?: string;
       };
     }[];
   };


### PR DESCRIPTION
Please note, this is a breaking change - you will need a new token with the required scopes to work 
(both `repo` and `read:org`). See README for details.
